### PR TITLE
Implement pagerduty integration resource and associated API client code

### DIFF
--- a/helper/test/config.go
+++ b/helper/test/config.go
@@ -10,11 +10,13 @@ import (
 const (
 	TestConfigAccountAccessToken TestConfigKey = iota
 	TestConfigAcceptanceTestKey
+	TestConfigPagerDutyAPIKey
 	TestConfigUserKey
 )
 
 var testConfigKeyToEnvName = map[TestConfigKey]string{
 	TestConfigAccountAccessToken: "ROLLBAR_ACCOUNT_ACCESS_TOKEN",
+	TestConfigPagerDutyAPIKey:    "ROLLBAR_PD_API_KEY",
 	TestConfigUserKey:            "ROLLBAR_USER",
 	TestConfigAcceptanceTestKey:  resource.TestEnvVar,
 }
@@ -71,4 +73,8 @@ func (t *TestConfig) SkipUnlessAccTest(testing *testing.T) {
 
 func (t *TestConfig) GetUserOrAbort(testing *testing.T) (val string) {
 	return t.GetOrAbort(testing, TestConfigUserKey)
+}
+
+func (t *TestConfig) GetPagerDutyAPIKeyorAbort(testing *testing.T) (val string) {
+	return t.GetOrAbort(testing, TestConfigPagerDutyAPIKey)
 }

--- a/rollapi/client.go
+++ b/rollapi/client.go
@@ -15,7 +15,7 @@ const (
 	DefaultAPIBaseURL = "https://api.rollbar.com/api/1"
 
 	// DefaultUserAgent is the user agent used when making API calls.
-	DefaultUserAgent = "go-rollbar-api"
+	DefaultUserAgent = "go-rollapi"
 
 	// RollbarAuthHeader is the Authorization header.
 	RollbarAuthHeader = "x-rollbar-access-token"

--- a/rollapi/client.go
+++ b/rollapi/client.go
@@ -39,6 +39,7 @@ type Client struct {
 	UserAgent string
 
 	// Services used for talking to different parts of the Rollbar API.
+	Notifications       *NotificationsService
 	Projects            *ProjectsService
 	ProjectAccessTokens *ProjectAccessTokensService
 	Teams               *TeamsService
@@ -74,7 +75,7 @@ type TokenAuthConfig struct {
 // NewClientTokenAuth constructs a new client to interact with the Rollbar API using a project or account access token.
 func NewClientTokenAuth(config *TokenAuthConfig) (*Client, error) {
 	// Validate that either ProjectAccessToken or AccountAccessToken are set in TokenAuthConfig.
-	if config.GetProjectAccessToken() != "" && config.GetAccountAccessToken() != "" {
+	if config.GetProjectAccessToken() == "" && config.GetAccountAccessToken() == "" {
 		return nil, fmt.Errorf("please set an account access token and/or a project access token for authentication")
 	}
 
@@ -95,6 +96,7 @@ func NewClientTokenAuth(config *TokenAuthConfig) (*Client, error) {
 // injectServices adds the services to the client.
 func (c *Client) injectServices() {
 	c.common.client = c
+	c.Notifications = (*NotificationsService)(&c.common)
 	c.Projects = (*ProjectsService)(&c.common)
 	c.ProjectAccessTokens = (*ProjectAccessTokensService)(&c.common)
 	c.Teams = (*TeamsService)(&c.common)
@@ -144,10 +146,12 @@ func (c *Client) Get(url string, v, body interface{}) (*Response, error) {
 
 // Post executes a POST http request.
 func (c *Client) Post(url string, v, body interface{}) (*Response, error) {
-	resp, err := c.http.R().SetResult(v).
-		SetBody(body).
-		Post(url)
+	req := c.http.R().SetBody(body)
 
+	if v != nil {
+		req.SetResult(v)
+	}
+	resp, err := req.Post(url)
 	if err != nil {
 		return nil, err
 	}
@@ -168,9 +172,12 @@ func (c *Client) Delete(url string, v interface{}) (*Response, error) {
 
 // Patch executes a PATCH http request.
 func (c *Client) Patch(url string, v, body interface{}) (*Response, error) {
-	resp, err := c.http.R().SetResult(v).
-		SetBody(body).
-		Patch(url)
+	req := c.http.R().SetBody(body)
+
+	if v != nil {
+		req.SetResult(v)
+	}
+	resp, err := req.Patch(url)
 	if err != nil {
 		return nil, err
 	}
@@ -180,9 +187,12 @@ func (c *Client) Patch(url string, v, body interface{}) (*Response, error) {
 
 // Put executes a PUT http request.
 func (c *Client) Put(url string, v, body interface{}) (*Response, error) {
-	resp, err := c.http.R().SetResult(v).
-		SetBody(body).
-		Put(url)
+	req := c.http.R().SetBody(body)
+
+	if v != nil {
+		req.SetResult(v)
+	}
+	resp, err := req.Put(url)
 	if err != nil {
 		return nil, err
 	}

--- a/rollapi/notifications_pagerduty.go
+++ b/rollapi/notifications_pagerduty.go
@@ -1,0 +1,89 @@
+package rollapi
+
+// NotificationsService handles communication with the notification related
+// methods of the Rollbar API.
+//
+// Rollbar API docs: https://docs.rollbar.com/reference#notifications
+type NotificationsService service
+
+// PDIntegrationRequest represents a request to configure Rollbar with PagerDuty.
+type PDIntegrationRequest struct {
+	Enabled    bool   `json:"enabled,omitempty"`
+	ServiceKey string `json:"service_key,omitempty"`
+}
+
+// PDRuleRequest represents a request to add one or many PagerDuty notification rule.
+type PDRuleRequest struct {
+	// As of Feb. 11th 2020, the only possible value for the Triggers field is `new_item`.
+	Trigger string          `json:"trigger,omitempty"`
+	Filters []*PDRuleFilter `json:"filters,omitempty"`
+	Config  *PDRuleConfig   `json:"config,omitempty"`
+}
+
+// PDRuleFilter represents a PagerDuty rule filter.
+type PDRuleFilter struct {
+	Type      string `json:"type,omitempty"`
+	Operation string `json:"operation,omitempty"`
+	Value     string `json:"value,omitempty"`
+}
+
+// PDRuleConfig represents the configuration options available on a rule.
+type PDRuleConfig struct {
+	// PagerDuty Service API Key. Make sure the ServiceKey string value is length 32.
+	ServiceKey string `json:"service_key,omitempty"`
+}
+
+// ConfigurePagerDuty configures the PagerDuty integration for a project.
+//
+// This function creates and modifies the PagerDuty integration. Requires a project access token.
+//
+// Rollbar API docs: https://docs.rollbar.com/reference#configuring-pagerduty-integration
+func (n *NotificationsService) ConfigurePagerDuty(opts *PDIntegrationRequest) (*Response, error) {
+	urlStr := n.client.requestURL("/notifications/pagerduty")
+
+	// Set the correct authentication header
+	n.client.setAuthTokenHeader(n.client.projectAccessToken)
+
+	// Execute the request
+	response, getErr := n.client.Put(urlStr, nil, opts)
+
+	return response, getErr
+}
+
+// ModifyPagerDutyRules creates & modifies PagerDuty notification rules for a project.
+//
+// Requires a project access token.
+// (The API documentation is wrong regarding which documentation to use as of Feb. 10th, 2020.)
+//
+// Rollbar API docs: https://docs.rollbar.com/reference#setup-pagerduty-notification-rules
+func (n *NotificationsService) ModifyPagerDutyRules(opts []*PDRuleRequest) (bool, *Response, error) {
+	urlStr := n.client.requestURL("/notifications/pagerduty/rules")
+
+	// Set the correct authentication header
+	n.client.setAuthTokenHeader(n.client.projectAccessToken)
+
+	// Execute the request
+	isSuccessful := false
+	response, getErr := n.client.Put(urlStr, nil, opts)
+	if getErr != nil {
+		return isSuccessful, response, getErr
+	}
+
+	if response.StatusCode == 200 {
+		isSuccessful = true
+	}
+
+	return isSuccessful, response, nil
+}
+
+// DeleteAllPagerDutyRules removes all rules for a project's PagerDuty notification integration.
+// This is the same ModifyPagerDutyRules but passes in an empty array as the request body for convenience.
+//
+// Requires a project access token.
+// (The API documentation is wrong regarding which documentation to use as of Feb. 10th, 2020.)
+//
+// Rollbar API docs: https://docs.rollbar.com/reference#setup-pagerduty-notification-rules
+func (n *NotificationsService) DeleteAllPagerDutyRules() (bool, *Response, error) {
+	opts := make([]*PDRuleRequest, 0)
+	return n.ModifyPagerDutyRules(opts)
+}

--- a/rollapi/notifications_pagerduty.go
+++ b/rollapi/notifications_pagerduty.go
@@ -8,7 +8,7 @@ type NotificationsService service
 
 // PDIntegrationRequest represents a request to configure Rollbar with PagerDuty.
 type PDIntegrationRequest struct {
-	Enabled    bool   `json:"enabled,omitempty"`
+	Enabled    *bool  `json:"enabled,omitempty"`
 	ServiceKey string `json:"service_key,omitempty"`
 }
 
@@ -33,12 +33,12 @@ type PDRuleConfig struct {
 	ServiceKey string `json:"service_key,omitempty"`
 }
 
-// ConfigurePagerDuty configures the PagerDuty integration for a project.
+// ConfigurePagerDutyIntegration configures the PagerDuty integration for a project.
 //
 // This function creates and modifies the PagerDuty integration. Requires a project access token.
 //
 // Rollbar API docs: https://docs.rollbar.com/reference#configuring-pagerduty-integration
-func (n *NotificationsService) ConfigurePagerDuty(opts *PDIntegrationRequest) (*Response, error) {
+func (n *NotificationsService) ConfigurePagerDutyIntegration(opts *PDIntegrationRequest) (*Response, error) {
 	urlStr := n.client.requestURL("/notifications/pagerduty")
 
 	// Set the correct authentication header

--- a/rollapi/rollapi-accessors.go
+++ b/rollapi/rollapi-accessors.go
@@ -139,6 +139,14 @@ func (p *PATUpdateRequest) GetRateLimitWindowSize() int {
 	return *p.RateLimitWindowSize
 }
 
+// GetEnabled returns the Enabled field if it's non-nil, zero value otherwise.
+func (p *PDIntegrationRequest) GetEnabled() bool {
+	if p == nil || p.Enabled == nil {
+		return false
+	}
+	return *p.Enabled
+}
+
 // GetConfig returns the Config field.
 func (p *PDRuleRequest) GetConfig() *PDRuleConfig {
 	if p == nil {

--- a/rollapi/rollapi-accessors.go
+++ b/rollapi/rollapi-accessors.go
@@ -139,6 +139,25 @@ func (p *PATUpdateRequest) GetRateLimitWindowSize() int {
 	return *p.RateLimitWindowSize
 }
 
+// GetConfig returns the Config field.
+func (p *PDRuleRequest) GetConfig() *PDRuleConfig {
+	if p == nil {
+		return nil
+	}
+	return p.Config
+}
+
+// HasFilters checks if PDRuleRequest has any Filters.
+func (p *PDRuleRequest) HasFilters() bool {
+	if p == nil || p.Filters == nil {
+		return false
+	}
+	if len(p.Filters) == 0 {
+		return false
+	}
+	return true
+}
+
 // GetAccountID returns the AccountID field if it's non-nil, zero value otherwise.
 func (p *Project) GetAccountID() int64 {
 	if p == nil || p.AccountID == nil {

--- a/rollbar/config.go
+++ b/rollbar/config.go
@@ -21,6 +21,7 @@ func NewConfig() *Config {
 func (c *Config) initializeAPI() error {
 	authConfig := &rollapi.TokenAuthConfig{
 		AccountAccessToken: &c.accountAccessToken,
+		ProjectAccessToken: &c.projectAccessToken,
 		CustomHTTPHeaders:  c.Headers,
 	}
 

--- a/rollbar/config.go
+++ b/rollbar/config.go
@@ -7,10 +7,11 @@ import (
 )
 
 type Config struct {
-	API                *rollapi.Client
-	Headers            map[string]string
-	accountAccessToken string
-	projectAccessToken string
+	API                                       *rollapi.Client
+	Headers                                   map[string]string
+	accountAccessToken                        string
+	projectAccessToken                        string
+	PostCreatePDIntegrationDeleteDefaultRules bool
 }
 
 func NewConfig() *Config {
@@ -42,6 +43,8 @@ func (c *Config) applySchema(d *schema.ResourceData) (err error) {
 		}
 		c.Headers = headers
 	}
+
+	c.PostCreatePDIntegrationDeleteDefaultRules = d.Get("post_create_pd_integration_delete_default_rules").(bool)
 
 	return nil
 }

--- a/rollbar/import_rollbar_pagerduty_integration_test.go
+++ b/rollbar/import_rollbar_pagerduty_integration_test.go
@@ -1,0 +1,29 @@
+package rollbar
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"regexp"
+	"testing"
+)
+
+func TestAccRollbarPagerDutyIntegration_importBasic(t *testing.T) {
+	key := testAccConfig.GetPagerDutyAPIKeyorAbort(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckRollbarPagerDutyIntegration_basic(key),
+			},
+			{
+				ResourceName:      "rollbar_pagerduty_integration.foobar",
+				ExpectError:       regexp.MustCompile(`not possible to import PagerDuty integration due to API limitations`),
+				ImportStateVerify: true,
+				ImportState:       true,
+			},
+		},
+	})
+}

--- a/rollbar/provider.go
+++ b/rollbar/provider.go
@@ -30,6 +30,8 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
+			"rollbar_pagerduty_integration": resourceRollbarPagerDutyIntegration(),
+			//"rollbar_pagerduty_notification_rule": resourceRollbarPagerDutyNotificationRule(),
 			"rollbar_project":              resourceRollbarProject(),
 			"rollbar_project_access_token": resourceRollbarProjectAccessToken(),
 			"rollbar_team":                 resourceRollbarTeam(),
@@ -51,10 +53,12 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	config := NewConfig()
 
 	if accountAccessToken, ok := d.GetOk("account_access_token"); ok {
+		log.Printf("[DEBUG] account_access_token to be used: %v", accountAccessToken)
 		config.accountAccessToken = accountAccessToken.(string)
 	}
 
 	if projectAccessToken, ok := d.GetOk("project_access_token"); ok {
+		log.Printf("[DEBUG] project_access_token to be used: %v", projectAccessToken)
 		config.projectAccessToken = projectAccessToken.(string)
 	}
 

--- a/rollbar/provider.go
+++ b/rollbar/provider.go
@@ -27,6 +27,12 @@ func Provider() terraform.ResourceProvider {
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("ROLLBAR_API_HEADERS", nil),
 			},
+
+			"post_create_pd_integration_delete_default_rules": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/rollbar/resource_rollbar_pagerduty_integration.go
+++ b/rollbar/resource_rollbar_pagerduty_integration.go
@@ -1,0 +1,116 @@
+package rollbar
+
+import (
+	"fmt"
+	"github.com/davidji99/terraform-provider-rollbar/rollapi"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"log"
+	"strconv"
+	"time"
+)
+
+func resourceRollbarPagerDutyIntegration() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceRollbarPagerDutyIntegrationCreate,
+		Read:   resourceRollbarPagerDutyIntegrationRead,
+		Delete: resourceRollbarPagerDutyIntegrationDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: resourceRollbarPagerDutyIntegrationImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"service_key": {
+				Type:         schema.TypeString,
+				Required:     true,
+				Sensitive:    true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(32, 32),
+			},
+
+			"enabled": {
+				Type:     schema.TypeBool,
+				ForceNew: true,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceRollbarPagerDutyIntegrationImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	return nil, fmt.Errorf("not possible to import PagerDuty integration due to API limitations")
+}
+
+func resourceRollbarPagerDutyIntegrationCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Config).API
+	opts := &rollapi.PDIntegrationRequest{}
+
+	if v, ok := d.GetOk("service_key"); ok {
+		vs := v.(string)
+		log.Printf("[DEBUG] service_key is : %s", vs)
+		opts.ServiceKey = vs
+	}
+
+	vs := d.Get("enabled").(bool)
+	log.Printf("[DEBUG] enabled is : %v", vs)
+	opts.Enabled = &vs
+
+	log.Printf("[DEBUG] Adding pagerduty integration %v", opts)
+
+	_, createErr := client.Notifications.ConfigurePagerDutyIntegration(opts)
+	if createErr != nil {
+		return createErr
+	}
+
+	log.Printf("[DEBUG] Added pagerduty integration %v", opts)
+
+	//if d.Get("delete_default_rules").(bool) {
+	//	log.Printf("[DEBUG] Deleting default rules added on service_key %s", opts.ServiceKey)
+	//
+	//	_, _, deleteErr := client.Notifications.DeleteAllPagerDutyRules()
+	//	if deleteErr != nil {
+	//		return deleteErr
+	//	}
+	//
+	//	log.Printf("[DEBUG] Deleted default rules added on service_key %s", opts.ServiceKey)
+	//}
+
+	// Set the resource ID to be the epoch time in nanoseconds
+	d.SetId(strconv.Itoa(time.Now().Nanosecond()))
+
+	return resourceRollbarPagerDutyIntegrationRead(d, meta)
+}
+
+func resourceRollbarPagerDutyIntegrationRead(d *schema.ResourceData, meta interface{}) error {
+	// There is no GET API endpoint so state will set whatever value is defined in the user's configuration.
+	var setErr error
+	setErr = d.Set("service_key", d.Get("service_key"))
+	setErr = d.Set("enabled", d.Get("enabled"))
+
+	return setErr
+}
+
+func resourceRollbarPagerDutyIntegrationDelete(d *schema.ResourceData, meta interface{}) error {
+	// There is no DELETE API endpoint so resource deletion will entail disabling the integration.
+	// Users will need to visit the UI to manually remove the integration.
+	client := meta.(*Config).API
+	opts := &rollapi.PDIntegrationRequest{}
+
+	opts.ServiceKey = d.Get("service_key").(string)
+	e := false
+	opts.Enabled = &e
+
+	log.Printf("[DEBUG] Disabling pagerduty integration %v", opts)
+
+	_, createErr := client.Notifications.ConfigurePagerDutyIntegration(opts)
+	if createErr != nil {
+		return createErr
+	}
+
+	log.Printf("[DEBUG] Disabled pagerduty integration %v", opts)
+
+	d.SetId("")
+
+	return nil
+}

--- a/rollbar/resource_rollbar_pagerduty_integration.go
+++ b/rollbar/resource_rollbar_pagerduty_integration.go
@@ -65,16 +65,16 @@ func resourceRollbarPagerDutyIntegrationCreate(d *schema.ResourceData, meta inte
 
 	log.Printf("[DEBUG] Added pagerduty integration %v", opts)
 
-	//if d.Get("delete_default_rules").(bool) {
-	//	log.Printf("[DEBUG] Deleting default rules added on service_key %s", opts.ServiceKey)
-	//
-	//	_, _, deleteErr := client.Notifications.DeleteAllPagerDutyRules()
-	//	if deleteErr != nil {
-	//		return deleteErr
-	//	}
-	//
-	//	log.Printf("[DEBUG] Deleted default rules added on service_key %s", opts.ServiceKey)
-	//}
+	if meta.(*Config).PostCreatePDIntegrationDeleteDefaultRules {
+		log.Printf("[DEBUG] Deleting default rules added on service_key %s", opts.ServiceKey)
+
+		_, _, deleteErr := client.Notifications.DeleteAllPagerDutyRules()
+		if deleteErr != nil {
+			return deleteErr
+		}
+
+		log.Printf("[DEBUG] Deleted default rules added on service_key %s", opts.ServiceKey)
+	}
 
 	// Set the resource ID to be the epoch time in nanoseconds
 	d.SetId(strconv.Itoa(time.Now().Nanosecond()))

--- a/rollbar/resource_rollbar_pagerduty_integration_test.go
+++ b/rollbar/resource_rollbar_pagerduty_integration_test.go
@@ -46,7 +46,7 @@ func testAccCheckRollbarPagerDutyIntegration_basic(key string) string {
 	return fmt.Sprintf(`
 resource "rollbar_pagerduty_integration" "foobar" {
 	service_key = "%s"
-	enabled = false
+	enabled = true
 }
 `, key)
 }

--- a/rollbar/resource_rollbar_pagerduty_integration_test.go
+++ b/rollbar/resource_rollbar_pagerduty_integration_test.go
@@ -1,0 +1,52 @@
+package rollbar
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"regexp"
+	"testing"
+)
+
+func TestAccRollbarPagerDutyIntegration_Basic(t *testing.T) {
+	key := testAccConfig.GetPagerDutyAPIKeyorAbort(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckRollbarPagerDutyIntegration_basic(key),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"rollbar_pagerduty_integration.foobar", "service_key", key),
+					resource.TestCheckResourceAttr(
+						"rollbar_pagerduty_integration.foobar", "enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRollbarPagerDutyIntegration_InvalidServiceKey(t *testing.T) {
+	key := "invalid_key"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckRollbarPagerDutyIntegration_basic(key),
+				ExpectError: regexp.MustCompile(`expected length of service_key to be in the range \(32 - 32\)`),
+			},
+		},
+	})
+}
+
+func testAccCheckRollbarPagerDutyIntegration_basic(key string) string {
+	return fmt.Sprintf(`
+resource "rollbar_pagerduty_integration" "foobar" {
+	service_key = "%s"
+	enabled = false
+}
+`, key)
+}

--- a/rollbar/resource_rollbar_project.go
+++ b/rollbar/resource_rollbar_project.go
@@ -58,14 +58,14 @@ func resourceRollbarProjectCreate(d *schema.ResourceData, meta interface{}) erro
 		opts.Name = vs
 	}
 
-	log.Printf("Creating new project %s", opts.Name)
+	log.Printf("[DEBUG] Creating new project %s", opts.Name)
 
 	newProject, _, createErr := client.Projects.Create(opts)
 	if createErr != nil {
 		return createErr
 	}
 
-	log.Printf("Created new project %s", opts.Name)
+	log.Printf("[DEBUG] Created new project %s", opts.Name)
 
 	d.SetId(Int64ToString(newProject.GetResult().GetID()))
 
@@ -91,7 +91,7 @@ func resourceRollbarProjectRead(d *schema.ResourceData, meta interface{}) error 
 func resourceRollbarProjectDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*Config).API
 
-	log.Printf("Project id to be deleted: %v", d.Id())
+	log.Printf("[DEBUG] Project id to be deleted: %v", d.Id())
 
 	_, deleteErr := client.Projects.Delete(StringToInt(d.Id()))
 	if deleteErr != nil {

--- a/rollbar/resource_rollbar_project_access_token.go
+++ b/rollbar/resource_rollbar_project_access_token.go
@@ -91,14 +91,14 @@ func resourceRollbarProjectAccessTokenImport(d *schema.ResourceData, meta interf
 	// To import this resource, users must pass in the project ID & access token as the 'ID'.
 	// We then proceed to set one half of the import ID as the "access_token"
 	// before generating a random string number to set as the real resource ID in state.
-	projectId, accessToken, parseErr := ParseCompositeID(d.Id())
+	projectID, accessToken, parseErr := ParseCompositeID(d.Id())
 	if parseErr != nil {
 		return nil, parseErr
 	}
 
 	var setErr error
 	setErr = d.Set("access_token", accessToken)
-	setErr = d.Set("project_id", StringToInt(projectId))
+	setErr = d.Set("project_id", StringToInt(projectID))
 	if setErr != nil {
 		return nil, setErr
 	}
@@ -230,13 +230,13 @@ func resourceRollbarProjectAccessTokenUpdate(d *schema.ResourceData, meta interf
 		return updateErr
 	}
 
-	log.Printf("Updated project access token %s", pat.GetResult().GetName())
+	log.Printf("[DEBUG] Updated project access token %s", pat.GetResult().GetName())
 
 	return resourceRollbarProjectAccessTokenRead(d, meta)
 }
 
 func resourceRollbarProjectAccessTokenDelete(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[INFO] There is no API DELETE support for project access token resource so this is a no-op. " +
+	log.Printf("[DEBUG] There is no API DELETE support for project access token resource so this is a no-op. " +
 		"Resource will be removed only from state.")
 	d.SetId("")
 

--- a/rollbar/resource_rollbar_team.go
+++ b/rollbar/resource_rollbar_team.go
@@ -66,14 +66,14 @@ func resourceRollbarTeamCreate(d *schema.ResourceData, meta interface{}) error {
 		opts.AccessLevel = vs
 	}
 
-	log.Printf("Creating new team %s", opts.Name)
+	log.Printf("[DEBUG] Creating new team %s", opts.Name)
 
 	newTeam, _, createErr := client.Teams.Create(opts)
 	if createErr != nil {
 		return createErr
 	}
 
-	log.Printf("Created new team %s", opts.Name)
+	log.Printf("[DEBUG] Created new team %s", opts.Name)
 
 	d.SetId(Int64ToString(newTeam.GetResult().GetID()))
 
@@ -99,7 +99,7 @@ func resourceRollbarTeamRead(d *schema.ResourceData, meta interface{}) error {
 func resourceRollbarTeamDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*Config).API
 
-	log.Printf("Team id to be deleted: %v", d.Id())
+	log.Printf("[DEBUG] Team id to be deleted: %v", d.Id())
 
 	_, deleteErr := client.Teams.Delete(StringToInt(d.Id()))
 	if deleteErr != nil {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -41,9 +41,13 @@ resource "rollbar_project" "service-x" {
 
 ## Authentication
 
-The Rollbar provider offers a flexible means of providing credentials for
-authentication. The following methods are supported, listed in order of
-precedence, and explained below:
+Certain resources in Rollbar require either the `account_access_token` or `project_access_token`. Based on observation,
+the `account_access_token` is used more frequently for this provider's resources. You must supply both tokens 
+if your terraform configuration code manages resources that require both access tokens. Otherwise, one access token
+must be supplied to your provider block or sourced from other means.
+
+The Rollbar provider offers a flexible means of providing credentials for authentication.
+The following methods are supported, listed in order of precedence, and explained below:
 
 * Static credentials
 * Environment variables
@@ -79,6 +83,15 @@ Refreshing Terraform state in-memory prior to plan...
 
 The following arguments are supported:
 
-* `account_access_token` - (Required) Rollbar account access token. It must be provided, but it can also
-  be sourced from [other locations](#Authentication). The provided token **MUST** have read & write permissions enabled
-  so the provider can completely manage supported resources.
+* `account_access_token` - (Required) Rollbar account access token. It can be provided, but it can also
+be sourced from [other locations](#Authentication). This token **MUST** have read & write permissions enabled
+so the provider can completely manage supported resources.
+
+* `project_access_token` - (Required) Rollbar project access token. It can be provided, but it can also
+be sourced from [other locations](#Authentication). This token **MUST** have read & write permissions enabled
+so the provider can completely manage supported resources.
+
+* `api_headers` - (Optional) Additional API headers.
+
+* `post_create_pd_integration_delete_default_rules` - (Optional) Delete the auto-added rules after enabling
+PagerDuty notification integration. Defaults to `false`.

--- a/website/docs/r/pagerduty_integration.html.markdown
+++ b/website/docs/r/pagerduty_integration.html.markdown
@@ -1,0 +1,46 @@
+---
+layout: "rollbar"
+page_title: "Rollbar: rollbar_pagerduty_integration"
+sidebar_current: "docs-rollbar-resource-pagerduty-integration"
+description: |-
+  Provides a resource to create and partially manage a Rollbar PagerDuty integration.
+---
+
+# rollbar\_pagerduty\_integration
+
+This resource is used manage Rollbar's integration with PagerDuty. You must supply a `project_access_token` with write
+permissions in other to manage this resource.
+
+~> NOTE: Due to API limitations, it is not possible to delete/remove the integration via the API.
+Therefore upon resource deletion, the existing PagerDuty integration will be disabled. Users must then visit the UI
+if they wish to remove the integration entirely by clearing out the 'Service API Key' field and click 'Save'.
+
+Users also have the option to set `post_create_pd_integration_delete_default_rules` to `true` in their `provider` block
+if they wish to delete the auto-added notification rules. This is recommended as the `rollbar_pagerduty_notification_rule`
+resource cannot import existing rules due to API limitations.
+
+## Example Usage
+
+```hcl
+# Create a new Rollbar project
+resource "rollbar_pagerduty_integration" "pd" {
+	service_key = "SOME_VALID_PD_KEY"
+	enabled = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `service_key` - (Required) `<string>` Valid PagerDuty Service API Key. Must 32 characters long.
+
+* `enabled` - (Required) `<boolean>` Enable the PagerDuty notifications globally
+
+## Attributes Reference
+
+N/A
+
+## Import
+
+Due to API limitations, it is not possible to import an existing PagerDuty integration.

--- a/website/docs/r/project.html.markdown
+++ b/website/docs/r/project.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 This resource is used to create and manage projects on Rollbar.
 
-**NOTE:** The Rollbar API does not support updating existing projects, only through the UI.
+~> NOTE: The Rollbar API does not support updating existing projects, only through the UI.
 Therefore, you must update your configuration file(s) for this resource if you manually updated
 the project name. Otherwise, your `terraform plan` will detect if a difference between the state file and remote.
 

--- a/website/rollbar.erb
+++ b/website/rollbar.erb
@@ -25,6 +25,10 @@
         <li<%= sidebar_current("docs-rollbar-resource") %>>
         <a href="#">Resources</a>
             <ul class="nav nav-visible">
+                <li<%= sidebar_current("docs-rollbar-resource-pagerduty-integration") %>>
+                  <a href="/docs/providers/rollbar/r/pagerduty_integration.html">rollbar_pagerduty_integration</a>
+                </li>
+
                 <li<%= sidebar_current("docs-rollbar-resource-project") %>>
                   <a href="/docs/providers/rollbar/r/project.html">rollbar_project</a>
                 </li>


### PR DESCRIPTION
JSON response after initial `PUT` and subsequent:
```
{
  "result": {},
  "err": 0
}
```

Potential rules JSON payload:
```
[
	{
		"trigger": "new_item",
		"filters": [
			{
				"type": "level",
				"operation": "gte",
				"value": "warning"	
				}
		]
	}
]
```

As the endpoint is a `PUT`, to delete a single rule, the full request body should have all the rules sans the rule in question. To delete all the rules, pass in an empty `[]` as the request body.

TODO: should delete all the default rules when the integration is added?