### PR TITLE
Update access token scopes

### DIFF
--- a/docs/resources/project_access_token.md
+++ b/docs/resources/project_access_token.md
@@ -55,7 +55,7 @@ The following arguments are supported:
 * `name` - (Required) `<string>` Name of the project access token. Max length 32 characters.
 
 * `scopes` - (Required) `<list(string)>` Scopes to assign to the create access token.
-Valid options: `read`, `write`, `post_server_item`, `post_client_server`.
+Valid options: `read`, `write`, `post_server_item`, `post_client_item`.
 
 * `status` - (Required) `<string>` Enable or disable the access token. Valid options: `enabled`, `disabled`.
 

--- a/rollbar/resource_rollbar_project_access_token.go
+++ b/rollbar/resource_rollbar_project_access_token.go
@@ -39,7 +39,7 @@ func resourceRollbarProjectAccessToken() *schema.Resource {
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 					ValidateFunc: validation.StringInSlice(
-						[]string{"read", "write", "post_server_item", "post_client_server"}, false),
+						[]string{"read", "write", "post_server_item", "post_client_item"}, false),
 				},
 			},
 

--- a/rollbar/resource_rollbar_project_access_token_test.go
+++ b/rollbar/resource_rollbar_project_access_token_test.go
@@ -48,7 +48,7 @@ func TestAccRollbarProjectAccessToken_InvalidScopes(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccCheckRollbarProjectAccessToken_InvalidScopes(projectName, tokenName),
-				ExpectError: regexp.MustCompile(`.*to be one of \[read write post_server_item post_client_server].*`),
+				ExpectError: regexp.MustCompile(`.*to be one of \[read write post_server_item post_client_item].*`),
 			},
 		},
 	})


### PR DESCRIPTION
I'm trying to create rollbar access tokens for client side application but the creation fails because `post_client_server` isn't accepted as value.
Even though the rollbar REST API [documentation](https://explorer.docs.rollbar.com/#tag/Project-Access-Tokens/paths/~1api~11~1project~1{id}~1access_tokens/post) reports `post_client_server` as accepted value for the scopes field, trying to call the API with that value it fails because `post_client_server` isn't accepted. Checking the rollbar terraform provider from Rollbar, it accepts `post_client_item` as value.
To be able to create access tokens for client applications, I changed all the occurrences of `post_client_server` with `post_client_server`