### PR TITLE
correct documentation link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ description: |-
 
 # Rollbar Provider
 
-The Rollbar provider is used to interact with the resources provided by [Rollbar API](https://explorer.docs.rollbar.com/).
+The Rollbar provider is used to interact with the resources provided by [Rollbar API](https://docs.rollbar.com/).
 
 ## Example Usage
 


### PR DESCRIPTION
explorer.docs.rollbar.com doesn't exist anymore.

Also, is this being used? Are there any differing features with https://github.com/rollbar/terraform-provider-rollbar?